### PR TITLE
Check if there is a filemanager that handles URIs

### DIFF
--- a/Source/Dialog/DialogProfile.cpp
+++ b/Source/Dialog/DialogProfile.cpp
@@ -99,11 +99,11 @@ DialogProfile::DialogProfile(BaseObjectType* cobject, gToxBuilder builder, const
     open_in_fm->signal_activate().connect([this, profile_list](){
         auto row = profile_list->get_selected_row();
         if (row) {
-            try {
-                Gio::AppInfo::get_default_for_type("inode/directory", true)->launch_uri(Glib::filename_to_uri(m_accounts[row->get_index()]));
-            } catch (...) {
-                //TODO: display error !
-            }
+            auto filemanager = Gio::AppInfo::get_default_for_type("inode/directory",
+                    true);
+            if (filemanager)
+                filemanager->launch_uri(
+                        Glib::filename_to_uri(m_accounts[row->get_index()]));
         }
     });
 

--- a/Source/Dialog/DialogProfile.cpp
+++ b/Source/Dialog/DialogProfile.cpp
@@ -99,8 +99,10 @@ DialogProfile::DialogProfile(BaseObjectType* cobject, gToxBuilder builder, const
     open_in_fm->signal_activate().connect([this, profile_list](){
         auto row = profile_list->get_selected_row();
         if (row) {
-            auto filemanager = Gio::AppInfo::get_default_for_type("inode/directory",
-                    true);
+            auto filemanager =
+                Gio::AppInfo::get_default_for_type("inode/directory", true);
+
+            // TODO Show user error if no filemanager
             if (filemanager)
                 filemanager->launch_uri(
                         Glib::filename_to_uri(m_accounts[row->get_index()]));


### PR DESCRIPTION
This stops a segfault if when opening trying to open a profile in
a file manager when there is no filemanager that handles URIs