### PR TITLE
detachable window base class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCES
     dialog/main.cpp
     dialog/chat.cpp
     dialog/settings.cpp
+    dialog/detachable_window.cpp
 
     widget/avatar.cpp
     widget/contact.cpp

--- a/src/dialog/chat.cpp
+++ b/src/dialog/chat.cpp
@@ -58,8 +58,8 @@ chat::chat(std::shared_ptr<toxmm::core> core,
     property_body() = m_body;
 
     m_binding_name = Glib::Binding::bind_property(m_contact->property_name_or_addr(),
-                                                     property_headerbar_title(),
-                                                     Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
+                                                  property_headerbar_title(),
+                                                  Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
 
     m_binding_status = Glib::Binding::bind_property(m_contact->property_status_message(),
                                                     property_headerbar_subtitle(),

--- a/src/dialog/chat.cpp
+++ b/src/dialog/chat.cpp
@@ -35,44 +35,35 @@ namespace sigc {
 
 using namespace dialog;
 
-chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
+chat::chat(std::shared_ptr<toxmm::core> core,
+           std::shared_ptr<toxmm::contact> contact,
+           detachable_window::type_slot_detachable_add slot_add_widget,
+           detachable_window::type_slot_detachable_add slot_del_widget):
+    Glib::ObjectBase(typeid(chat)),
+    detachable_window(slot_add_widget, slot_del_widget),
+    m_core(core),
     m_contact(contact),
-    m_main(main),
     m_builder(Gtk::Builder::create_from_resource("/org/gtox/ui/dialog_chat.ui")) {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), { contact->property_name_or_addr().get_value().raw() });
 
-    m_builder.get_widget("chat_headerbar_attached", m_headerbar_attached);
-    m_builder.get_widget("chat_headerbar_detached", m_headerbar_detached);
     m_builder.get_widget("chat_body", m_body);
     m_input = m_builder.get_widget_derived<widget::chat_input>("chat_input");
     m_builder.get_widget("chat_input_revealer", m_input_revealer);
     m_builder.get_widget("chat_input_format_revealer", m_input_format_revealer);
-    m_builder.get_widget("btn_prev", m_btn_prev);
-    m_builder.get_widget("btn_next", m_btn_next);
-    m_builder.get_widget("chat_attach", m_btn_attach);
-    m_builder.get_widget("chat_detach", m_btn_detach);
-    m_builder.get_widget("close_btn_attached", m_btn_close_attached);
-    m_builder.get_widget("close_btn_detached", m_btn_close_detached);
     m_builder.get_widget("chat_box", m_chat_box);
     m_builder.get_widget("eventbox", m_eventbox);
     m_builder.get_widget("scrolled", m_scrolled);
     m_builder.get_widget("viewport", m_viewport);
 
-    m_main.chat_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
+    property_body() = m_body;
 
-    m_binding_name[0] = Glib::Binding::bind_property(m_contact->property_name_or_addr(),
-                                                     m_headerbar_attached->property_title(),
-                                                     Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
-    m_binding_name[1] = Glib::Binding::bind_property(m_contact->property_name_or_addr(),
-                                                     m_headerbar_detached->property_title(),
+    m_binding_name = Glib::Binding::bind_property(m_contact->property_name_or_addr(),
+                                                     property_headerbar_title(),
                                                      Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
 
-    m_binding_status[0] = Glib::Binding::bind_property(m_contact->property_status_message(),
-                                                       m_headerbar_attached->property_subtitle(),
-                                                       Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
-    m_binding_status[1] = Glib::Binding::bind_property(m_contact->property_status_message(),
-                                                       m_headerbar_detached->property_subtitle(),
-                                                       Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
+    m_binding_status = Glib::Binding::bind_property(m_contact->property_status_message(),
+                                                    property_headerbar_subtitle(),
+                                                    Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);
 
     m_binding_online = Glib::Binding::bind_property(m_contact->property_connection(),
                                  m_input_revealer->property_reveal_child(),
@@ -82,38 +73,6 @@ chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
         is_online = connection != TOX_CONNECTION_NONE;
         return true;
     });
-
-    /*m_binding_focus = Glib::Binding::bind_property(m_input->property_has_focus(),
-                                 m_input_format_revealer->property_reveal_child(),
-                                 Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE);*/
-
-    set_titlebar(*m_headerbar_detached);
-    m_btn_detach->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        m_main.property_gravity() = Gdk::GRAVITY_NORTH_WEST;
-        int x, y;
-        m_main.get_position(x, y);
-        move(x, y);
-        resize(m_body->get_width(), m_main.get_height());
-        m_main.chat_remove(*m_headerbar_attached, *m_body);
-        add(*m_body);
-        show();
-    }, *this));
-    m_btn_attach->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        remove();
-        hide();
-        m_main.chat_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
-    }, *this));
-    m_btn_close_attached->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        m_main.chat_remove(*m_headerbar_attached, *m_body);
-    }, *this));
-    m_btn_close_detached->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        remove();
-        hide();
-    }, *this));
 
     m_input->signal_key_press_event().connect(sigc::track_obj([this](GdkEventKey* event) {
         utils::debug::scope_log log(DBG_LVL_3("gtox"), {});
@@ -137,14 +96,17 @@ chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
 
     m_contact->signal_send_message().connect(sigc::track_obj([this](Glib::ustring message, std::shared_ptr<toxmm::receipt>) {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), { message.raw() });
-        auto time = Glib::DateTime::create_now_utc();
-        add_chat_line(
-            LINE_APPEND_APPENDABLE,
-            m_main.tox(),
-            time,
-            Gtk::manage(new widget::chat_message(m_main.tox()->property_name_or_addr(),
-                                                 time,
-                                                 message)));
+        auto core = m_core.lock();
+        if (core) {
+            auto time = Glib::DateTime::create_now_utc();
+            add_chat_line(
+                LINE_APPEND_APPENDABLE,
+                core,
+                time,
+                Gtk::manage(new widget::chat_message(core->property_name_or_addr(),
+                                                     time,
+                                                     message)));
+        }
     }, *this));
 
     m_contact->signal_recv_message().connect(sigc::track_obj([this](Glib::ustring message) {
@@ -161,14 +123,17 @@ chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
 
     m_contact->signal_send_action().connect(sigc::track_obj([this](Glib::ustring action, std::shared_ptr<toxmm::receipt>) {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), { action.raw() });
-        auto time = Glib::DateTime::create_now_utc();
-        add_chat_line(
-            LINE_NEW,
-            m_main.tox(),
-            Glib::DateTime::create_now_utc(),
-            Gtk::manage(new widget::chat_action(m_main.tox()->property_name_or_addr(),
-                                                time,
-                                                action)));
+        auto core = m_core.lock();
+        if (core) {
+            auto time = Glib::DateTime::create_now_utc();
+            add_chat_line(
+                LINE_APPEND_APPENDABLE,
+                core,
+                time,
+                Gtk::manage(new widget::chat_action(core->property_name_or_addr(),
+                                                    time,
+                                                    action)));
+        }
     }, *this));
 
     m_contact->signal_recv_action().connect(sigc::track_obj([this](Glib::ustring action) {
@@ -201,13 +166,16 @@ chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
         if (file->property_kind() != TOX_FILE_KIND_DATA) {
             return;
         }
-        auto b_ref = widget::file::create(file);
-        auto widget = b_ref.raw();
-        add_chat_line(
-            LINE_APPEND_APPENDABLE,
-            m_main.tox(),
-            Glib::DateTime::create_now_utc(),
-            Gtk::manage(widget));
+        auto core = m_core.lock();
+        if (core) {
+            auto b_ref = widget::file::create(file);
+            auto widget = b_ref.raw();
+            add_chat_line(
+                LINE_APPEND_APPENDABLE,
+                core,
+                Glib::DateTime::create_now_utc(),
+                Gtk::manage(widget));
+        }
     }, *this));
 
     //logic for text-selection
@@ -328,18 +296,8 @@ chat::chat(dialog::main& main, std::shared_ptr<toxmm::contact> contact):
 
 chat::~chat() {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    m_main.chat_remove(*m_headerbar_attached, *m_body);
     //why do I need to manually delete m_input ?
     delete m_input;
-}
-
-void chat::activated() {
-    utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    if (is_visible()) {
-        present();
-    } else {
-        m_main.chat_show(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
-    }
 }
 
 void chat::update_children(GdkEventMotion* event,
@@ -413,9 +371,12 @@ Glib::ustring chat::get_children_selection(
 
 void chat::load_log() {
     utils::debug::scope_log lo(DBG_LVL_1("gtox"), {});
-    auto c = m_main.tox();
+    auto c = m_core.lock();
+    if (!c) {
+        return;
+    }
     auto cm = c->contact_manager();
-    if (!c || !cm) {
+    if (!cm) {
         return;
     }
 

--- a/src/dialog/chat.h
+++ b/src/dialog/chat.h
@@ -44,16 +44,7 @@ namespace dialog {
             utils::dispatcher m_dispatcher;
             utils::builder    m_builder;
 
-            Gtk::HeaderBar* m_headerbar_attached;
-            Gtk::HeaderBar* m_headerbar_detached;
             Gtk::Widget* m_body;
-
-            Gtk::Button* m_btn_attach;
-            Gtk::Button* m_btn_detach;
-            Gtk::Button* m_btn_prev;
-            Gtk::Button* m_btn_next;
-            Gtk::Button* m_btn_close_attached;
-            Gtk::Button* m_btn_close_detached;
 
             Gtk::EventBox* m_eventbox;
 

--- a/src/dialog/chat.h
+++ b/src/dialog/chat.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include "resources/flatbuffers/generated/Log_generated.h"
 #include "utils/debug.h"
+#include "detachable_window.h"
 
 namespace widget {
     class chat_input;
@@ -35,11 +36,11 @@ namespace widget {
 
 namespace dialog {
     class main;
-    class chat : public Gtk::Window, public utils::debug::track_obj<chat> {
+    class chat : public detachable_window, public utils::debug::track_obj<chat> {
         private:
+            std::weak_ptr<toxmm::core> m_core;
             std::shared_ptr<toxmm::contact> m_contact;
 
-            main& m_main;
             utils::dispatcher m_dispatcher;
             utils::builder    m_builder;
 
@@ -65,10 +66,9 @@ namespace dialog {
 
             Gtk::Box* m_chat_box;
 
-            Glib::RefPtr<Glib::Binding> m_binding_name[2];
-            Glib::RefPtr<Glib::Binding> m_binding_status[2];
+            Glib::RefPtr<Glib::Binding> m_binding_name;
+            Glib::RefPtr<Glib::Binding> m_binding_status;
             Glib::RefPtr<Glib::Binding> m_binding_online;
-            Glib::RefPtr<Glib::Binding> m_binding_focus;
 
             enum class SIDE {
                 NONE,
@@ -114,14 +114,15 @@ namespace dialog {
                                Glib::DateTime time,
                                Gtk::Widget* widget);
         public:
-            chat(main& main, std::shared_ptr<toxmm::contact> contact);
+            chat(std::shared_ptr<toxmm::core> core,
+                 std::shared_ptr<toxmm::contact> contact,
+                 detachable_window::type_slot_detachable_add slot_add_widget,
+                 detachable_window::type_slot_detachable_del slot_del_widget);
             ~chat();
 
             static void add_log(std::shared_ptr<toxmm::storage> storage,
                                 std::shared_ptr<toxmm::contact> contact,
                                 std::function<flatbuffers::Offset<flatbuffers::Log::Item>(flatbuffers::FlatBufferBuilder&)> create_func);
-
-            void activated();
     };
 }
 

--- a/src/dialog/detachable_window.cpp
+++ b/src/dialog/detachable_window.cpp
@@ -88,8 +88,20 @@ detachable_window::detachable_window(type_slot_detachable_add main_add,
 
     m_btn_detach->signal_clicked().connect(sigc::track_obj([this, main_del]() {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        Gtk::Widget* body = property_body().get_value();
+        Gtk::Window* parent = dynamic_cast<Gtk::Window *>(body->get_toplevel());
+        if (parent) {
+            auto gravity = parent->get_gravity();
+            int x, y, w, h;
+            parent->set_gravity(Gdk::GRAVITY_NORTH_WEST);
+            parent->get_position(x, y);
+            parent->get_size(w, h);
+            parent->set_gravity(gravity);
+            move(x, y);
+            resize(body->get_width(), h);
+        }
         main_del(this);
-        add(*property_body());
+        add(*body);
         show();
     }, *this));
     m_btn_attach->signal_clicked().connect(sigc::track_obj([this, main_add]() {

--- a/src/dialog/detachable_window.cpp
+++ b/src/dialog/detachable_window.cpp
@@ -1,0 +1,158 @@
+/**
+    gTox a GTK-based tox-client - https://github.com/KoKuToru/gTox.git
+
+    Copyright (C) 2015  Luca Béla Palkovics
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>
+**/
+#include "detachable_window.h"
+#include "main.h"
+using namespace dialog;
+
+auto detachable_window::property_has_focus()          -> Glib::PropertyProxy<bool> {
+    return m_prop_has_focus.get_proxy();
+}
+
+auto detachable_window::property_is_attached()        -> Glib::PropertyProxy<bool> {
+    return m_prop_is_attached.get_proxy();
+}
+
+auto detachable_window::property_headerbar_title()    -> Glib::PropertyProxy<Glib::ustring> {
+    return m_prop_headerbar_title.get_proxy();
+}
+
+auto detachable_window::property_headerbar_subtitle() -> Glib::PropertyProxy<Glib::ustring> {
+    return m_prop_headerbar_subtitle.get_proxy();
+}
+
+auto detachable_window::property_body()               -> Glib::PropertyProxy<Gtk::Widget*> {
+    return m_prop_body.get_proxy();
+}
+
+detachable_window::type_signal_close detachable_window::signal_close() {
+    return m_signal_close;
+}
+
+detachable_window::detachable_window(type_signal_detachable_add main_add,
+                                     type_signal_detachable_del main_del)
+    : Glib::ObjectBase(typeid(detachable_window)),
+      m_builder(Gtk::Builder::create_from_resource("/org/gtox/ui/dialog_detachable.ui")),
+      m_prop_has_focus(*this, "detachable-window-has-focus", false),
+      m_prop_is_attached(*this, "detachable-window-is-attached", true),
+      m_prop_headerbar_title(*this, "detachable-window-headerbar-title"),
+      m_prop_headerbar_subtitle(*this, "detachable-window-headerbar-subtitle"),
+      m_prop_body(*this, "detachable-window-body") {
+    utils::debug::scope_log(DBG_LVL_1("gtox"), {});
+    m_builder.get_widget("headerbar_attached", m_headerbar_attached);
+    m_builder.get_widget("headerbar_detached", m_headerbar_detached);
+    m_builder.get_widget("attach", m_btn_attach);
+    m_builder.get_widget("detach", m_btn_detach);
+    m_builder.get_widget("btn_attached", m_btn_close_attached);
+    m_builder.get_widget("btn_detached", m_btn_close_detached);
+
+    auto bind_flags = Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE;
+    m_bindings.push_back(Glib::Binding::bind_property(
+                             property_headerbar_title(),
+                             m_headerbar_attached->property_title(),
+                             bind_flags));
+    m_bindings.push_back(Glib::Binding::bind_property(
+                             property_headerbar_title(),
+                             m_headerbar_detached->property_title(),
+                             bind_flags));
+    m_bindings.push_back(Glib::Binding::bind_property(
+                             property_headerbar_subtitle(),
+                             m_headerbar_attached->property_subtitle(),
+                             bind_flags));
+    m_bindings.push_back(Glib::Binding::bind_property(
+                             property_headerbar_subtitle(),
+                             m_headerbar_detached->property_subtitle(),
+                             bind_flags));
+
+    m_btn_detach->signal_clicked().connect(sigc::track_obj([this, main_del]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        main_del(this);
+        add(*property_body());
+        show();
+    }, *this));
+    m_btn_attach->signal_clicked().connect(sigc::track_obj([this, main_add]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        remove();
+        main_add(this);
+        hide();
+    }, *this));
+    m_btn_close_attached->signal_clicked().connect(sigc::track_obj([this, main_del]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        main_del(this);
+        m_signal_close();
+    }, *this));
+    m_btn_close_detached->signal_clicked().connect(sigc::track_obj([this]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        remove();
+        hide();
+        m_signal_close();
+    }, *this));
+
+    auto update_has_focus = [this]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        auto body = property_body().get_value();
+        auto parent = dynamic_cast<Gtk::Window *>(body->get_toplevel());
+
+        m_prop_has_focus = (property_is_attached()
+                            && parent
+                            && parent->property_is_active()
+                            && body->get_mapped())
+                           || property_is_active().get_value();
+    };
+
+    property_body()
+            .signal_changed()
+            .connect(sigc::track_obj([this,
+                                     main_add,
+                                     main_del,
+                                     update_has_focus]() {
+        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        auto body = property_body().get_value();
+
+        if (property_is_attached()) {
+            main_del(this);
+            if (body) {
+                main_add(this);
+            }
+        } else {
+            remove();
+            if (body) {
+                add(*property_body());
+            }
+        }
+
+        if (body) {
+            body->signal_map()
+                    .connect_notify(
+                        sigc::track_obj(update_has_focus, *this, *body));
+            body->signal_unmap()
+                    .connect_notify(
+                        sigc::track_obj(update_has_focus, *this, *body));
+        }
+    }, *this));
+
+    property_is_active()
+            .signal_changed()
+            .connect(sigc::track_obj(update_has_focus, *this));
+
+    set_titlebar(*m_headerbar_detached);
+}
+
+detachable_window::~detachable_window() {
+    utils::debug::scope_log(DBG_LVL_1("gtox"), {});
+}

--- a/src/dialog/detachable_window.cpp
+++ b/src/dialog/detachable_window.cpp
@@ -40,19 +40,24 @@ auto detachable_window::property_body()               -> Glib::PropertyProxy<Gtk
     return m_prop_body.get_proxy();
 }
 
+auto detachable_window::property_headerbar()          -> Glib::PropertyProxy_ReadOnly<Gtk::HeaderBar*> {
+    return {this, "detachable-window-headerbar"};
+}
+
 detachable_window::type_signal_close detachable_window::signal_close() {
     return m_signal_close;
 }
 
-detachable_window::detachable_window(type_signal_detachable_add main_add,
-                                     type_signal_detachable_del main_del)
+detachable_window::detachable_window(type_slot_detachable_add main_add,
+                                     type_slot_detachable_del main_del)
     : Glib::ObjectBase(typeid(detachable_window)),
       m_builder(Gtk::Builder::create_from_resource("/org/gtox/ui/dialog_detachable.ui")),
       m_prop_has_focus(*this, "detachable-window-has-focus", false),
       m_prop_is_attached(*this, "detachable-window-is-attached", true),
       m_prop_headerbar_title(*this, "detachable-window-headerbar-title"),
       m_prop_headerbar_subtitle(*this, "detachable-window-headerbar-subtitle"),
-      m_prop_body(*this, "detachable-window-body") {
+      m_prop_body(*this, "detachable-window-body"),
+      m_prop_headerbar(*this, "detachable-window-headerbar") {
     utils::debug::scope_log(DBG_LVL_1("gtox"), {});
     m_builder.get_widget("headerbar_attached", m_headerbar_attached);
     m_builder.get_widget("headerbar_detached", m_headerbar_detached);
@@ -60,6 +65,8 @@ detachable_window::detachable_window(type_signal_detachable_add main_add,
     m_builder.get_widget("detach", m_btn_detach);
     m_builder.get_widget("btn_attached", m_btn_close_attached);
     m_builder.get_widget("btn_detached", m_btn_close_detached);
+
+    m_prop_headerbar = m_headerbar_attached;
 
     auto bind_flags = Glib::BINDING_DEFAULT | Glib::BINDING_SYNC_CREATE;
     m_bindings.push_back(Glib::Binding::bind_property(

--- a/src/dialog/detachable_window.h
+++ b/src/dialog/detachable_window.h
@@ -37,15 +37,16 @@ namespace dialog {
             auto property_headerbar_title()    -> Glib::PropertyProxy<Glib::ustring>;
             auto property_headerbar_subtitle() -> Glib::PropertyProxy<Glib::ustring>;
             auto property_body()               -> Glib::PropertyProxy<Gtk::Widget*>;
+            auto property_headerbar()          -> Glib::PropertyProxy_ReadOnly<Gtk::HeaderBar*>;
 
-            using type_signal_detachable_add = sigc::signal<void, detachable_window*>;
-            using type_signal_detachable_del = sigc::signal<void, detachable_window*>;
-            using type_signal_close          = sigc::signal<void>;
+            using type_slot_detachable_add = sigc::slot<void, detachable_window*>;
+            using type_slot_detachable_del = sigc::slot<void, detachable_window*>;
+            using type_signal_close        = sigc::signal<void>;
 
             type_signal_close signal_close();
 
-            detachable_window(type_signal_detachable_add main_add,
-                              type_signal_detachable_del main_del);
+            detachable_window(type_slot_detachable_add main_add,
+                              type_slot_detachable_del main_del);
             virtual ~detachable_window();
 
         private:
@@ -60,11 +61,12 @@ namespace dialog {
 
             std::vector<Glib::RefPtr<Glib::Binding>> m_bindings;
 
-            Glib::Property<bool>          m_prop_has_focus;
-            Glib::Property<bool>          m_prop_is_attached;
-            Glib::Property<Glib::ustring> m_prop_headerbar_title;
-            Glib::Property<Glib::ustring> m_prop_headerbar_subtitle;
-            Glib::Property<Gtk::Widget*>  m_prop_body;
+            Glib::Property<bool>            m_prop_has_focus;
+            Glib::Property<bool>            m_prop_is_attached;
+            Glib::Property<Glib::ustring>   m_prop_headerbar_title;
+            Glib::Property<Glib::ustring>   m_prop_headerbar_subtitle;
+            Glib::Property<Gtk::Widget*>    m_prop_body;
+            Glib::Property<Gtk::HeaderBar*> m_prop_headerbar;
 
             type_signal_close m_signal_close;
     };

--- a/src/dialog/detachable_window.h
+++ b/src/dialog/detachable_window.h
@@ -1,0 +1,73 @@
+/**
+    gTox a GTK-based tox-client - https://github.com/KoKuToru/gTox.git
+
+    Copyright (C) 2015  Luca Béla Palkovics
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>
+**/
+#ifndef DIALOGDETACHABLEWINDOW_H
+#define DIALOGDETACHABLEWINDOW_H
+
+#include <gtkmm.h>
+#include "utils/debug.h"
+#include "utils/builder.h"
+
+namespace dialog {
+
+    class main;
+
+    class detachable_window
+            : public Gtk::Window,
+              public utils::debug::track_obj<detachable_window> {
+        public:
+            //props
+            auto property_has_focus()          -> Glib::PropertyProxy<bool>;
+            auto property_is_attached()        -> Glib::PropertyProxy<bool>;
+            auto property_headerbar_title()    -> Glib::PropertyProxy<Glib::ustring>;
+            auto property_headerbar_subtitle() -> Glib::PropertyProxy<Glib::ustring>;
+            auto property_body()               -> Glib::PropertyProxy<Gtk::Widget*>;
+
+            using type_signal_detachable_add = sigc::signal<void, detachable_window*>;
+            using type_signal_detachable_del = sigc::signal<void, detachable_window*>;
+            using type_signal_close          = sigc::signal<void>;
+
+            type_signal_close signal_close();
+
+            detachable_window(type_signal_detachable_add main_add,
+                              type_signal_detachable_del main_del);
+            virtual ~detachable_window();
+
+        private:
+            utils::builder m_builder;
+
+            Gtk::HeaderBar* m_headerbar_attached;
+            Gtk::HeaderBar* m_headerbar_detached;
+            Gtk::Button* m_btn_attach;
+            Gtk::Button* m_btn_detach;
+            Gtk::Button* m_btn_close_attached;
+            Gtk::Button* m_btn_close_detached;
+
+            std::vector<Glib::RefPtr<Glib::Binding>> m_bindings;
+
+            Glib::Property<bool>          m_prop_has_focus;
+            Glib::Property<bool>          m_prop_is_attached;
+            Glib::Property<Glib::ustring> m_prop_headerbar_title;
+            Glib::Property<Glib::ustring> m_prop_headerbar_subtitle;
+            Glib::Property<Gtk::Widget*>  m_prop_body;
+
+            type_signal_close m_signal_close;
+    };
+}
+
+#endif

--- a/src/dialog/main.cpp
+++ b/src/dialog/main.cpp
@@ -476,6 +476,29 @@ void main::chat_add(Gtk::Widget& headerbar, Gtk::Widget& body, Gtk::Button& prev
     m_stack->show();
 }
 
+void main::chat_add(Gtk::Widget& headerbar, Gtk::Widget& body) {
+    utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
+    headerbar.get_style_context()->add_class("gtox-headerbar-left");
+
+    m_stack_header->add(headerbar);
+    m_stack->add(body);
+
+    m_stack_header->set_visible_child(headerbar);
+    m_stack->set_visible_child(body);
+
+    m_stack_data.push_back({&headerbar, &body});
+
+    //present
+    property_gravity() = Gdk::GRAVITY_NORTH_EAST;
+    if (!m_stack_header->is_visible()) {
+        resize(800 + get_width(), get_height());
+    }
+
+    m_stack_header->show();
+    m_stack->show();
+}
+
+
 void main::chat_remove(Gtk::Widget& headerbar, Gtk::Widget& body) {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
     for (size_t i = 0; i < m_stack_data.size(); ++i) {

--- a/src/dialog/main.h
+++ b/src/dialog/main.h
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "storage.h"
 #include "utils/debug.h"
+#include "detachable_window.h"
 
 namespace dialog {
     // contact list with pinned chat
@@ -82,10 +83,8 @@ namespace dialog {
 
             static utils::builder::ref<main> create(const Glib::ustring& file);
 
-            void chat_add   (Gtk::Widget& headerbar, Gtk::Widget& body, Gtk::Button& prev, Gtk::Button& next);
-            void chat_add   (Gtk::Widget& headerbar, Gtk::Widget& body);
-            void chat_remove(Gtk::Widget& headerbar, Gtk::Widget& body);
-            void chat_show  (Gtk::Widget& headerbar, Gtk::Widget& body, Gtk::Button& prev, Gtk::Button& next);
+            void detachable_window_add(dialog::detachable_window* window);
+            void detachable_window_del(dialog::detachable_window* window);
 
             void exit();
 

--- a/src/dialog/main.h
+++ b/src/dialog/main.h
@@ -83,6 +83,7 @@ namespace dialog {
             static utils::builder::ref<main> create(const Glib::ustring& file);
 
             void chat_add   (Gtk::Widget& headerbar, Gtk::Widget& body, Gtk::Button& prev, Gtk::Button& next);
+            void chat_add   (Gtk::Widget& headerbar, Gtk::Widget& body);
             void chat_remove(Gtk::Widget& headerbar, Gtk::Widget& body);
             void chat_show  (Gtk::Widget& headerbar, Gtk::Widget& body, Gtk::Button& prev, Gtk::Button& next);
 

--- a/src/dialog/settings.cpp
+++ b/src/dialog/settings.cpp
@@ -39,15 +39,7 @@ settings::settings(main& main)
       m_main(main) {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
 
-    m_builder.get_widget("headerbar_attached", m_headerbar_attached);
-    m_builder.get_widget("headerbar_detached", m_headerbar_detached);
     m_builder.get_widget("body", m_body);
-    m_builder.get_widget("attach", m_btn_attach);
-    m_builder.get_widget("detach", m_btn_detach);
-    m_builder.get_widget("btn_prev", m_btn_prev);
-    m_builder.get_widget("btn_next", m_btn_next);
-    m_builder.get_widget("close_btn_attached", m_btn_close_attached);
-    m_builder.get_widget("close_btn_detached", m_btn_close_detached);
 
     m_builder.get_widget("tray_visible" , m_tray_visible);
     m_builder.get_widget("tray_on_start", m_tray_on_start);

--- a/src/dialog/settings.cpp
+++ b/src/dialog/settings.cpp
@@ -73,7 +73,7 @@ settings::settings(main& main)
 
     m_builder.get_widget("video_default_device", m_video_device);
 
-    m_main.chat_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
+    m_main.detachable_window_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
 
     m_headerbar_attached->set_title(_("gTox settings"));
     m_headerbar_detached->set_title(_("gTox settings"));
@@ -87,7 +87,7 @@ settings::settings(main& main)
         m_main.get_position(x, y);
         move(x, y);
         resize(m_body->get_width(), m_main.get_height());
-        m_main.chat_remove(*m_headerbar_attached, *m_body);
+        m_main.detachable_window_del(*m_headerbar_attached, *m_body);
         add(*m_body);
         show();
     }, *this));
@@ -95,11 +95,11 @@ settings::settings(main& main)
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
         remove();
         hide();
-        m_main.chat_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
+        m_main.detachable_window_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
     }, *this));
     m_btn_close_attached->signal_clicked().connect(sigc::track_obj([this]() {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        m_main.chat_remove(*m_headerbar_attached, *m_body);
+        m_main.detachable_window_del(*m_headerbar_attached, *m_body);
     }, *this));
     m_btn_close_detached->signal_clicked().connect(sigc::track_obj([this]() {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
@@ -283,5 +283,5 @@ void settings::activated() {
 
 settings::~settings() {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    m_main.chat_remove(*m_headerbar_attached, *m_body);
+    m_main.detachable_window_del(*m_headerbar_attached, *m_body);
 }

--- a/src/dialog/settings.cpp
+++ b/src/dialog/settings.cpp
@@ -30,7 +30,12 @@ namespace sigc {
 #include <iostream>
 
 settings::settings(main& main)
-    : m_builder(Gtk::Builder::create_from_resource("/org/gtox/ui/dialog_settings.ui")),
+    : Glib::ObjectBase(typeid(settings)),
+      detachable_window(sigc::mem_fun(main,
+                                      &dialog::main::detachable_window_add),
+                        sigc::mem_fun(main,
+                                      &dialog::main::detachable_window_del)),
+      m_builder(Gtk::Builder::create_from_resource("/org/gtox/ui/dialog_settings.ui")),
       m_main(main) {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
 
@@ -73,40 +78,10 @@ settings::settings(main& main)
 
     m_builder.get_widget("video_default_device", m_video_device);
 
-    m_main.detachable_window_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
+    property_body() = m_body;
 
-    m_headerbar_attached->set_title(_("gTox settings"));
-    m_headerbar_detached->set_title(_("gTox settings"));
-    m_headerbar_attached->set_subtitle(_("Configure gTox"));
-    m_headerbar_detached->set_subtitle(_("Configure gTox"));
-
-    m_btn_detach->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        m_main.property_gravity() = Gdk::GRAVITY_NORTH_WEST;
-        int x, y;
-        m_main.get_position(x, y);
-        move(x, y);
-        resize(m_body->get_width(), m_main.get_height());
-        m_main.detachable_window_del(*m_headerbar_attached, *m_body);
-        add(*m_body);
-        show();
-    }, *this));
-    m_btn_attach->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        remove();
-        hide();
-        m_main.detachable_window_add(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
-    }, *this));
-    m_btn_close_attached->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        m_main.detachable_window_del(*m_headerbar_attached, *m_body);
-    }, *this));
-    m_btn_close_detached->signal_clicked().connect(sigc::track_obj([this]() {
-        utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
-        remove();
-        hide();
-    }, *this));
-
+    property_headerbar_title() = _("gTox settings");
+    property_headerbar_subtitle() = _("Configure gTox");
 
     auto binding_flag = Glib::BINDING_DEFAULT |
                         Glib::BINDING_SYNC_CREATE |
@@ -267,21 +242,8 @@ settings::settings(main& main)
                              config::global().property_video_default_device(),
                              m_video_device->property_active_id(),
                              binding_flag));
-
-
-    set_titlebar(*m_headerbar_detached);
-}
-
-void settings::activated() {
-    utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    if (is_visible()) {
-        present();
-    } else {
-        m_main.chat_show(*m_headerbar_attached, *m_body, *m_btn_prev, *m_btn_next);
-    }
 }
 
 settings::~settings() {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    m_main.detachable_window_del(*m_headerbar_attached, *m_body);
 }

--- a/src/dialog/settings.h
+++ b/src/dialog/settings.h
@@ -23,10 +23,11 @@
 #include "utils/builder.h"
 #include "config.h"
 #include "utils/debug.h"
+#include "detachable_window.h"
 
 namespace dialog {
     class main;
-    class settings : public Gtk::Window, public utils::debug::track_obj<settings> {
+    class settings : public detachable_window, public utils::debug::track_obj<settings> {
         private:
             utils::builder m_builder;
             main& m_main;

--- a/src/dialog/settings.h
+++ b/src/dialog/settings.h
@@ -32,16 +32,7 @@ namespace dialog {
             utils::builder m_builder;
             main& m_main;
 
-            Gtk::HeaderBar* m_headerbar_attached;
-            Gtk::HeaderBar* m_headerbar_detached;
             Gtk::Widget* m_body;
-
-            Gtk::Button* m_btn_detach;
-            Gtk::Button* m_btn_attach;
-            Gtk::Button* m_btn_prev;
-            Gtk::Button* m_btn_next;
-            Gtk::Button* m_btn_close_attached;
-            Gtk::Button* m_btn_close_detached;
 
             Gtk::Switch* m_tray_visible;
             Gtk::Switch* m_tray_on_start;

--- a/src/resources/ui/CMakeLists.txt
+++ b/src/resources/ui/CMakeLists.txt
@@ -21,7 +21,8 @@ set(SRC
     dialog_chat.ui
     chat_bubble_right.ui
     chat_bubble_left.ui
-    videoplayer.ui)
+    videoplayer.ui
+    dialog_detachable.ui)
 
 set(LAYOUT ${SRC} PARENT_SCOPE)
 

--- a/src/resources/ui/dialog_detachable.ui
+++ b/src/resources/ui/dialog_detachable.ui
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.19.0 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkHeaderBar" id="detached">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title">Title</property>
+    <property name="subtitle">Subtitle</property>
+    <child>
+      <object class="GtkButton" id="attach">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <child>
+          <object class="GtkImage" id="image3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">view-restore-symbolic</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="position">2</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="box5">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="has_tooltip">True</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkSeparator" id="separator1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btn_detached">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkImage" id="image8">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">window-close-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="titlebutton"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <style>
+          <class name="right"/>
+        </style>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkHeaderBar" id="headerbar_attached">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title">Title</property>
+    <property name="subtitle">Subtitle</property>
+    <child>
+      <object class="GtkButton" id="detach">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <child>
+          <object class="GtkImage" id="image2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">view-paged-symbolic</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="box3">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="has_tooltip">True</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkSeparator" id="separator2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btn_attached">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkImage" id="image4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">window-close-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="titlebutton"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <style>
+          <class name="right"/>
+        </style>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/src/resources/ui/dialog_detachable.ui
+++ b/src/resources/ui/dialog_detachable.ui
@@ -2,7 +2,77 @@
 <!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <object class="GtkHeaderBar" id="detached">
+  <object class="GtkHeaderBar" id="headerbar_attached">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="title">Title</property>
+    <property name="subtitle">Subtitle</property>
+    <child>
+      <object class="GtkButton" id="detach">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+        <child>
+          <object class="GtkImage" id="image2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">view-paged-symbolic</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="box3">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="has_tooltip">True</property>
+        <property name="spacing">6</property>
+        <child>
+          <object class="GtkSeparator" id="separator2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btn_attached">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="valign">center</property>
+            <child>
+              <object class="GtkImage" id="image4">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">window-close-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="titlebutton"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <style>
+          <class name="right"/>
+        </style>
+      </object>
+      <packing>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+  <object class="GtkHeaderBar" id="headerbar_detached">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="title">Title</property>
@@ -50,76 +120,6 @@
             <property name="valign">center</property>
             <child>
               <object class="GtkImage" id="image8">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">window-close-symbolic</property>
-              </object>
-            </child>
-            <style>
-              <class name="titlebutton"/>
-            </style>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <style>
-          <class name="right"/>
-        </style>
-      </object>
-      <packing>
-        <property name="pack_type">end</property>
-        <property name="position">1</property>
-      </packing>
-    </child>
-  </object>
-  <object class="GtkHeaderBar" id="headerbar_attached">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="title">Title</property>
-    <property name="subtitle">Subtitle</property>
-    <child>
-      <object class="GtkButton" id="detach">
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-        <child>
-          <object class="GtkImage" id="image2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="icon_name">view-paged-symbolic</property>
-          </object>
-        </child>
-      </object>
-    </child>
-    <child>
-      <object class="GtkBox" id="box3">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="has_tooltip">True</property>
-        <property name="spacing">6</property>
-        <child>
-          <object class="GtkSeparator" id="separator2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="orientation">vertical</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="btn_attached">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="valign">center</property>
-            <child>
-              <object class="GtkImage" id="image4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="icon_name">window-close-symbolic</property>

--- a/src/widget/contact.cpp
+++ b/src/widget/contact.cpp
@@ -317,14 +317,10 @@ void contact::activated() {
     if (m_chat) {
         //m_chat->activated();
     } else {
-        auto attach = sigc::track_obj([this](dialog::detachable_window* window) {
-            m_main.chat_add(*window->property_headerbar(),
-                            *window->property_body());
-        }, *this, m_main);
-        auto detach = sigc::track_obj([this](dialog::detachable_window* window) {
-            m_main.chat_remove(*window->property_headerbar(),
-                               *window->property_body());
-        }, *this, m_main);
+        auto attach = sigc::mem_fun(m_main,
+                                    &dialog::main::detachable_window_add);
+        auto detach = sigc::mem_fun(m_main,
+                                    &dialog::main::detachable_window_del);
         m_chat = std::make_shared<dialog::chat>(m_main.tox(),
                                                 m_contact,
                                                 attach,

--- a/src/widget/main_menu.cpp
+++ b/src/widget/main_menu.cpp
@@ -70,6 +70,9 @@ main_menu::main_menu(dialog::main& main): m_main(main) {
             //m_settings->activated();
         } else {
             m_settings = Glib::RefPtr<dialog::settings>(new dialog::settings(m_main));
+            m_settings->signal_close().connect(sigc::track_obj([this]() {
+                m_settings.reset();
+            }, *this));
         }
     }, *this));
 

--- a/src/widget/main_menu.cpp
+++ b/src/widget/main_menu.cpp
@@ -69,8 +69,9 @@ main_menu::main_menu(dialog::main& main): m_main(main) {
         if (m_settings) {
             //m_settings->activated();
         } else {
-            m_settings = Glib::RefPtr<dialog::settings>(new dialog::settings(m_main));
+            m_settings = std::make_shared<dialog::settings>(m_main);
             m_settings->signal_close().connect(sigc::track_obj([this]() {
+                utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
                 m_settings.reset();
             }, *this));
         }

--- a/src/widget/main_menu.cpp
+++ b/src/widget/main_menu.cpp
@@ -67,7 +67,7 @@ main_menu::main_menu(dialog::main& main): m_main(main) {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
         hide();
         if (m_settings) {
-            m_settings->activated();
+            //m_settings->activated();
         } else {
             m_settings = Glib::RefPtr<dialog::settings>(new dialog::settings(m_main));
         }

--- a/src/widget/main_menu.h
+++ b/src/widget/main_menu.h
@@ -34,7 +34,7 @@ namespace widget {
     class main_menu : public Gtk::Popover, public utils::debug::track_obj<main_menu> {
         private:
             dialog::main& m_main;
-            Glib::RefPtr<dialog::settings> m_settings;
+            std::shared_ptr<dialog::settings> m_settings;
 
             struct {
                     Gtk::Entry* username;


### PR DESCRIPTION
`dialog::chat` and `dialog::settings` both are detachable windows.
At the moment code is duplicated..

`dialog::detachable_window` will include all the logic for attach/detach.
Independent of `dialog::main`