### PR TITLE
improved popover hack

### DIFF
--- a/src/dialog/main.cpp
+++ b/src/dialog/main.cpp
@@ -141,6 +141,9 @@ main::main(BaseObjectType* cobject,
     auto setting_btn = builder.get_widget<Gtk::Button>("setting_btn");
     setting_btn->signal_clicked().connect([this, setting_btn]() {
         utils::debug::scope_log log(DBG_LVL_2("gtox"), {});
+        if (m_menu->is_visible()) {
+            return;
+        }
         m_menu->set_position(Gtk::POS_BOTTOM);
         m_menu->set_relative_to(*setting_btn);
         m_menu->set_visible();

--- a/src/widget/main_menu.cpp
+++ b/src/widget/main_menu.cpp
@@ -176,7 +176,8 @@ void main_menu::set_visible(bool visible) {
 
 void main_menu::add_contact() {
     utils::debug::scope_log log(DBG_LVL_1("gtox"), {});
-    Gtk::Window& parent = dynamic_cast<Gtk::Window&>(*this->get_toplevel());
+    Gtk::Window& parent = dynamic_cast<Gtk::Window&>(*get_relative_to()
+                                                     ->get_toplevel());
 
     if (m_add_contact.tox_id->get_text().length() != TOX_ADDRESS_SIZE * 2) {
         dialog::error(parent, false,

--- a/src/widget/popover.cpp
+++ b/src/widget/popover.cpp
@@ -20,33 +20,43 @@
 #ifdef GDK_WINDOWING_WAYLAND
     #include <gdk/gdkwayland.h>
 #endif
+#include <gdk/gdkcairo.h>
 
 using namespace widget;
 
-popover::popwin::popwin() {
+popover::popwin::popwin(Gtk::Widget* widget)
+    : m_widget(widget) {
     add(area);
     area.show();
     set_decorated(false);
     set_app_paintable(true);
-    set_keep_above(true);
     set_skip_taskbar_hint(true);
     set_skip_pager_hint(true);
-    set_type_hint(Gdk::WINDOW_TYPE_HINT_TOOLTIP);
+    set_type_hint(Gdk::WINDOW_TYPE_HINT_DIALOG);
     auto visual = get_screen()->get_rgba_visual();
     if (visual) {
         gtk_widget_set_visual(GTK_WIDGET(gobj()), visual->gobj());
     }
 }
 
-bool popover::popwin::on_draw(const Cairo::RefPtr<Cairo::Context>& cr)
-{
+bool popover::popwin::on_draw(const Cairo::RefPtr<Cairo::Context>& cr) {
     auto res = Gtk::Window::on_draw(cr);
-    // get size of drawing ? would be nice..
-    /*
-    cr->rectangle(100, 100, 100, 100);
-    cr->stroke();
-    input_shape_combine_region(Cairo::Region::create(Cairo::RectangleInt{100,100,100,100}));
-    */
+
+    int x, y;
+    auto alloc = m_widget->get_allocation();
+    m_widget->translate_coordinates(*this,
+                                    alloc.get_x(),
+                                    alloc.get_y(),
+                                    x,
+                                    y);
+
+    input_shape_combine_region(Cairo::Region::create(Cairo::RectangleInt{
+                                                         x,
+                                                         y,
+                                                         alloc.get_width(),
+                                                         alloc.get_height()
+                                                     }));
+
     return res;
 }
 
@@ -56,7 +66,20 @@ popover::popover() {
             delete m_popwin;
             m_popwin = nullptr;
         }
+    }, *this), true);
+    property_relative_to().signal_changed().connect(sigc::track_obj([this]() {
+        if (m_popwin) {
+            delete m_popwin;
+            show();
+        }
     }, *this));
+}
+
+popover::~popover() {
+    if (m_popwin) {
+        delete m_popwin;
+        m_popwin = nullptr;
+    }
 }
 
 void popover::show() {
@@ -64,9 +87,15 @@ void popover::show() {
         return;
     }
 
+    if (!get_relative_to()) {
+        // need a relative to
+        return;
+    }
+
 #ifdef GDK_IS_WAYLAND_DISPLAY
     if (GDK_IS_WAYLAND_DISPLAY(gtk_widget_get_display(GTK_WIDGET(gobj())))) {
         // normal simple route
+        Gtk::Popover::set_relative_to(*get_relative_to());
         Gtk::Popover::show();
         return;
     }
@@ -74,12 +103,14 @@ void popover::show() {
     auto visual = get_relative_to()->get_screen()->get_rgba_visual();
     if (!visual) {
         // normal route with cropped popover
+        Gtk::Popover::set_relative_to(*get_relative_to());
         Gtk::Popover::show();
         return;
     }
 
     // open transparent window
-    m_popwin = new popwin();
+    m_popwin = new popwin(this);
+    m_popwin->set_focus_on_map();
 
     // set right screen
     m_popwin->set_screen(get_relative_to()->get_screen());
@@ -91,6 +122,9 @@ void popover::show() {
     // move/resize to right monitor
     m_popwin->move(rect.get_x(), rect.get_y());
     m_popwin->resize(rect.get_width(), rect.get_height());
+    m_popwin->set_transient_for(
+                dynamic_cast<Gtk::Window&>(
+                    *get_relative_to()->get_toplevel()));
     m_popwin->show_now();
 
     // calculate position for popover
@@ -109,9 +143,28 @@ void popover::show() {
     m_popwin->get_window()->get_root_origin(rx, ry);
 
     // set position for popover
-    set_relative_to(m_popwin->area);
+    Gtk::Popover::set_relative_to(m_popwin->area);
     set_pointing_to(Gdk::Rectangle(wx-rx, wy-ry, ww, wh));
 
     // open popover
     Gtk::Popover::show();
+
+    // the following generates WARNINGS ?
+    // GLib-GObject-WARNING **: gsignal.c:2595: handler 'x' of instance 'y' is not blocked
+    get_relative_to()->get_toplevel()->signal_focus_in_event()
+            .connect_notify(sigc::track_obj([this](GdkEventFocus*) {
+        Gtk::Popover::hide();
+    }, *this));
+}
+
+void popover::set_relative_to(Gtk::Widget& widget) {
+    property_relative_to() = &widget;
+}
+
+Gtk::Widget* popover::get_relative_to() {
+    return property_relative_to();
+}
+
+Glib::PropertyProxy<Gtk::Widget*> popover::property_relative_to() {
+    return m_property_helper.m_property_relative_to.get_proxy();
 }

--- a/src/widget/popover.h
+++ b/src/widget/popover.h
@@ -33,16 +33,27 @@ namespace widget {
     class popover: public Gtk::Popover {
         private:
             class popwin: public Gtk::Window {
+                    Gtk::Widget* m_widget;
                 public:
                     Gtk::Box area;
-                    popwin();
+                    popwin(Gtk::Widget* widget);
                     virtual bool on_draw(const Cairo::RefPtr<Cairo::Context>& cr) override;
             };
 
             popwin* m_popwin = nullptr;
 
+            // no idea why I can't do this directly in popover
+            class property_helper: public Glib::Object {
+                public:
+                    Glib::Property<Gtk::Widget*> m_property_relative_to;
+                    property_helper():
+                        Glib::ObjectBase(typeid(property_helper)),
+                        m_property_relative_to(*this, "popover-relative-to") {}
+            } m_property_helper;
+
         public:
             popover();
+            ~popover();
 
             void show();
             void set_visible(bool v) {
@@ -52,6 +63,10 @@ namespace widget {
                     hide();
                 }
             }
+
+            Glib::PropertyProxy<Gtk::Widget*> property_relative_to();
+            void set_relative_to(Gtk::Widget& widget);
+            Gtk::Widget* get_relative_to();
     };
 }
 #endif


### PR DESCRIPTION
* adds `property_relative_to`
* uses `Gdk::WINDOW_TYPE_HINT_DIALOG`, can auto focus window
* uses `input_shape_combine_region`
* sets `set_transient_for`
* adds `signal_focus_in_event`, hide popover when `get_relative_to()-
>get_toplevel()` gets focused